### PR TITLE
use http_host instedad of server_name for X-Forwarded-Host

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -26,7 +26,7 @@ http {
 
         location / {
             proxy_pass http://netbox:8001;
-            proxy_set_header X-Forwarded-Host $server_name;
+            proxy_set_header X-Forwarded-Host $http_host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-Proto $scheme;
             add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';


### PR DESCRIPTION
when using /api/doc/ swagger (openapi) json gets generated wrong host, because django-rest-swagger relies on this header