### PR TITLE
Builds snapshot image again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ after_success:
   - docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
   - if [ "$TRAVIS_BRANCH" = "master" -a "$TRAVIS_PULL_REQUEST" = "false" ]; then
       ./build.sh master --push;
+      ./build.sh develop --push;
       ./build-latest.sh --push;
       PRERELEASE=true ./build-latest.sh --push;
     fi


### PR DESCRIPTION
When we built netbox-docker on our internal Jenkins server, we built the following branches and versions:

* `master` branch became the image with the `latest` tag
* `develop` branch became the image with the `snapshot` tag
* _the latest stable version_ was built and tagged with the respective version tag

The travis build enhanced this automatic setup by building also the latest pre-release version, and tagging it accordingly. But building the `develop` branch got forgotten. This is now corrected with this pull request again.