### PR TITLE
Added ttf-ubuntu-font-family

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apk add --no-cache \
       ca-certificates \
       cyrus-sasl-dev \
       graphviz \
+      ttf-ubuntu-font-family \
       jpeg-dev \
       libffi-dev \
       libxml2-dev \


### PR DESCRIPTION
The present build does not include a font-family causing Graphviz to render text as blank squares, including the ttf ubuntu font-family means text is rendered correctly