### PR TITLE
Add named volume for postgres data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,8 @@ services:
     postgres:
         image: postgres:9.6-alpine
         env_file: postgres.env
+        volumes:
+        - netbox-postgres-data:/var/lib/postgresql/data
 
 volumes:
     netbox-static-files:
@@ -37,3 +39,6 @@ volumes:
         driver: local
     netbox-report-files:
         driver: local
+    netbox-postgres-data:
+        driver: local
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,4 +41,3 @@ volumes:
         driver: local
     netbox-postgres-data:
         driver: local
-


### PR DESCRIPTION
I found it difficult to remember which volume was associated to which container when it was not specifically named.

This simply names the volume that `postgres` uses for persistent data.

This will also be helpful for backup purposes.

Feel free to squash these two commits as the 2nd simply removed an unnecessary new line.