### PR TITLE
Load custom fields when creating the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,34 @@ For example defining `ALLOWED_HOSTS=localhost ::1 127.0.0.1` would allows access
 
 [compose-env]: https://docs.docker.com/compose/environment-variables/
 
+## Adding Netbox Custom Fields
+
+When using `docker-compose`, all the python scripts present in `docker/startup_scripts` will automatically be executed after the application boots.
+
+That mechanism can be used for many things, and in particular to load Netbox custom fields:
+
+```python
+# docker/startup_scripts/load_custom_fields.py
+from django.contrib.contenttypes.models import ContentType
+from extras.models import CF_TYPE_TEXT, CustomField
+
+from dcim.models import Device
+from dcim.models import DeviceType
+
+device      = ContentType.objects.get_for_model(Device)
+device_type = ContentType.objects.get_for_model(DeviceType)
+
+my_custom_field, created = CustomField.objects.get_or_create(
+    type=CF_TYPE_TEXT,
+    name='my_custom_field',
+    description='My own custom field'
+)
+
+if created:
+  my_custom_field.obj_type.add(device)
+  my_custom_field.obj_type.add(device_type)
+```
+
 ### Production
 
 The default settings are optimized for (local) development environments.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
         - postgres
         env_file: netbox.env
         volumes:
+        - ./docker/startup_scripts:/opt/netbox/netbox/startup_scripts
         - netbox-nginx-config:/etc/netbox-nginx/
         - netbox-static-files:/opt/netbox/netbox/static
         - netbox-media-files:/opt/netbox/netbox/media

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -39,6 +39,10 @@ if not User.objects.filter(username='${SUPERUSER_NAME}'):
     Token.objects.create(user=u, key='${SUPERUSER_API_TOKEN}')
 END
 
+for script in $(ls startup_scripts/*.py 2> /dev/null); do
+  ./manage.py shell --plain < "${script}"
+done
+
 # copy static files
 ./manage.py collectstatic --no-input
 


### PR DESCRIPTION
### What's new?

This is a general mechanism to launch python scripts for Netbox: All the scripts put inside the `docker/startup_scripts` folder will be executed.

