### PR TITLE
Do not print the admin credentials on container startup.

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -29,7 +29,6 @@ if [ -z ${SUPERUSER_API_TOKEN+x} ]; then
   fi
 fi
 
-echo "💡 Username: ${SUPERUSER_NAME}, E-Mail: ${SUPERUSER_EMAIL}, Password: ${SUPERUSER_PASSWORD}, Token: ${SUPERUSER_API_TOKEN}"
 
 ./manage.py shell --plain << END
 from django.contrib.auth.models import User


### PR DESCRIPTION
All outputs from STDOUT may end up in a central log store. This will compromise the superuser credentials.