### PR TITLE
Update to Alpine 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6-alpine
+FROM python:3.6-alpine3.7
 
 RUN apk add --no-cache \
       bash \
@@ -12,7 +12,6 @@ RUN apk add --no-cache \
       libxml2-dev \
       libxslt-dev \
       openldap-dev \
-      openssl-dev \
       postgresql-dev \
       wget
 


### PR DESCRIPTION
Because the tag "python:3.6-alpine" points to Alpine 3.4 which is now
end of life (as of 2018-05-01) the image now pulls the Alpine 3.7 python
image