### PR TITLE
Adding support for building on arm64v8

### DIFF
--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -1,0 +1,59 @@
+FROM arm64v8/python:3.6-alpine
+
+# RUN apk upgrade --update-cache --available
+RUN apk add --no-cache \
+      bash \
+      build-base \
+      ca-certificates \
+      cyrus-sasl-dev \
+      graphviz \
+      ttf-ubuntu-font-family \
+      jpeg-dev \
+      libffi-dev \
+      libxml2-dev \
+      libxslt-dev \
+      openldap-dev \
+# This dependency fails while building
+#     openssl-dev \
+      libressl-dev \
+      postgresql-dev \
+      wget
+
+RUN pip install \
+# gunicorn is used for launching netbox
+      gunicorn \
+# napalm is used for gathering information from network devices
+      napalm \
+# ruamel is used in startup_scripts
+      ruamel.yaml
+
+WORKDIR /opt
+
+ARG BRANCH=master
+ARG URL=https://github.com/digitalocean/netbox/archive/$BRANCH.tar.gz
+RUN wget -q -O - "${URL}" | tar xz \
+  && mv netbox* netbox
+
+WORKDIR /opt/netbox
+RUN pip install -r requirements.txt
+
+COPY docker/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py
+COPY configuration/gunicorn_config.py /etc/netbox/config/
+COPY docker/nginx.conf /etc/netbox-nginx/nginx.conf
+COPY docker/docker-entrypoint.sh docker-entrypoint.sh
+COPY startup_scripts/ /opt/netbox/startup_scripts/
+COPY initializers/ /opt/netbox/initializers/
+COPY configuration/configuration.py /etc/netbox/config/configuration.py
+
+WORKDIR /opt/netbox/netbox
+
+ENTRYPOINT [ "/opt/netbox/docker-entrypoint.sh" ]
+
+VOLUME ["/etc/netbox-nginx/"]
+
+CMD ["gunicorn", "-c /etc/netbox/config/gunicorn_config.py", "netbox.wsgi"]
+
+LABEL SRC_URL="$URL"
+
+ARG NETBOX_DOCKER_PROJECT_VERSION=snapshot
+LABEL NETBOX_DOCKER_PROJECT_VERSION="$NETBOX_DOCKER_PROJECT_VERSION"

--- a/docker-compose.arm64v8.yml
+++ b/docker-compose.arm64v8.yml
@@ -1,0 +1,47 @@
+version: '3'
+services:
+    netbox:
+        build:
+          context: .
+          dockerfile: Dockerfile.arm64v8
+          args:
+            - BRANCH=${VERSION-master}
+        image: ninech/netbox:${VERSION-latest}
+        depends_on:
+        - postgres
+        env_file: netbox.env
+        volumes:
+        - ./startup_scripts:/opt/netbox/startup_scripts:ro
+        - ./initializers:/opt/netbox/initializers:ro
+        - ./configuration:/etc/netbox/config:ro
+        - netbox-nginx-config:/etc/netbox-nginx/
+        - netbox-static-files:/opt/netbox/netbox/static
+        - netbox-media-files:/opt/netbox/netbox/media
+        - netbox-report-files:/etc/netbox/reports:ro
+    nginx:
+        image: arm64v8/nginx:1.13-alpine
+        command: nginx -g 'daemon off;' -c /etc/netbox-nginx/nginx.conf
+        depends_on:
+        - netbox
+        ports:
+        - 8080
+        volumes:
+        - netbox-static-files:/opt/netbox/netbox/static:ro
+        - netbox-nginx-config:/etc/netbox-nginx/:ro
+    postgres:
+        image: arm64v8/postgres:10.4-alpine
+        env_file: postgres.env
+        volumes:
+        - netbox-postgres-data:/var/lib/postgresql/data
+
+volumes:
+    netbox-static-files:
+        driver: local
+    netbox-nginx-config:
+        driver: local
+    netbox-media-files:
+        driver: local
+    netbox-report-files:
+        driver: local
+    netbox-postgres-data:
+        driver: local


### PR DESCRIPTION
This adds a Dockerfile.arm64v8 which successfully builds on a Pine64.   Additionally a docker-compose.arm64v8.yaml is also supplied and was successfully built and tested on the same Pine64.

Additionally for successful builds to occur, openssl-dev was replaced with libressl-dev in the Dockerfile.  This apparently is a know dependency issue with alpine-linux and openssl-dev.