### PR TITLE
resolve AUTH_LDAP_GROUP_CACHE_TIMEOUT from env

### DIFF
--- a/configuration/ldap_config.py
+++ b/configuration/ldap_config.py
@@ -45,7 +45,7 @@ AUTH_LDAP_FIND_GROUP_PERMS = os.environ.get('AUTH_LDAP_FIND_GROUP_PERMS', 'True'
 
 # Cache groups for one hour to reduce LDAP traffic
 AUTH_LDAP_CACHE_GROUPS = os.environ.get('AUTH_LDAP_CACHE_GROUPS', 'True').lower() == 'true'
-AUTH_LDAP_GROUP_CACHE_TIMEOUT = int(os.environ.get('AUTH_LDAP_CACHE_GROUPS', 3600))
+AUTH_LDAP_GROUP_CACHE_TIMEOUT = int(os.environ.get('AUTH_LDAP_GROUP_CACHE_TIMEOUT', 3600))
 
 # Populate the Django user from the LDAP directory.
 AUTH_LDAP_USER_ATTR_MAP = {


### PR DESCRIPTION
Resolve ValueError: invalid literal for int() for AUTH_LDAP_GROUP_CACHE_TIMEOUT