### PR TITLE
Update docker-entrypoint.sh

### DIFF
--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -31,7 +31,7 @@ fi
 
 echo "💡 Username: ${SUPERUSER_NAME}, E-Mail: ${SUPERUSER_EMAIL}"
 
-./manage.py shell --plain << END
+./manage.py shell --interface python << END
 from django.contrib.auth.models import User
 from users.models import Token
 if not User.objects.filter(username='${SUPERUSER_NAME}'):
@@ -41,7 +41,7 @@ END
 
 for script in /opt/netbox/startup_scripts/*.py; do
   echo "⚙️ Executing '$script'"
-  ./manage.py shell --plain < "${script}"
+  ./manage.py shell --interface python < "${script}"
 done
 
 # copy static files


### PR DESCRIPTION
Make netbox-docker function with  v2.4-beta1 again, fixes #84.

> The shell --plain option is deprecated in favor of -i python or --interface python.
> The shell --interface option now accepts python to force use of the “plain” Python interpreter.
https://docs.djangoproject.com/en/2.0/releases/1.10/#deprecated-features-1-10