### PR TITLE
Ignore missing initializers

### DIFF
--- a/startup_scripts/000_users.py
+++ b/startup_scripts/000_users.py
@@ -2,8 +2,14 @@ from django.contrib.auth.models import Permission, Group, User
 from users.models import Token
 
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/users.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/users.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml=YAML(typ='safe')
   users = yaml.load(stream)
 

--- a/startup_scripts/010_groups.py
+++ b/startup_scripts/010_groups.py
@@ -1,7 +1,13 @@
 from django.contrib.auth.models import Permission, Group, User
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/groups.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/groups.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml=YAML(typ='safe')
   groups = yaml.load(stream)
 

--- a/startup_scripts/020_custom_fields.py
+++ b/startup_scripts/020_custom_fields.py
@@ -2,6 +2,8 @@ from extras.constants import CF_TYPE_TEXT, CF_TYPE_INTEGER, CF_TYPE_BOOLEAN, CF_
 from extras.models import CustomField, CustomFieldChoice
 
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
 text_to_fields = {
   'boolean': CF_TYPE_BOOLEAN,
@@ -21,7 +23,11 @@ def get_class_for_class_path(class_path):
   clazz = getattr(module, class_name)
   return ContentType.objects.get_for_model(clazz)
 
-with open('/opt/netbox/initializers/custom_fields.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/custom_fields.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   customfields = yaml.load(stream)
 

--- a/startup_scripts/030_regions.py
+++ b/startup_scripts/030_regions.py
@@ -1,7 +1,13 @@
 from dcim.models import Region
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/regions.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/regions.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml=YAML(typ='safe')
   regions = yaml.load(stream)
 

--- a/startup_scripts/040_sites.py
+++ b/startup_scripts/040_sites.py
@@ -2,8 +2,14 @@ from dcim.models import Region, Site
 from extras.models import CustomField, CustomFieldValue
 from tenancy.models import Tenant
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/sites.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/sites.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   sites = yaml.load(stream)
 

--- a/startup_scripts/050_manufacturers.py
+++ b/startup_scripts/050_manufacturers.py
@@ -1,7 +1,13 @@
 from dcim.models import Manufacturer
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/manufacturers.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/manufacturers.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   manufacturers = yaml.load(stream)
 

--- a/startup_scripts/060_device_types.py
+++ b/startup_scripts/060_device_types.py
@@ -2,8 +2,14 @@ from dcim.models import DeviceType, Manufacturer, Region
 from tenancy.models import Tenant
 from extras.models import CustomField, CustomFieldValue
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/device_types.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/device_types.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   device_types = yaml.load(stream)
 
@@ -48,4 +54,3 @@ with open('/opt/netbox/initializers/device_types.yml', 'r') as stream:
             device_type.custom_field_values.add(custom_field_value)
 
         print("🔡 Created device type", device_type.manufacturer, device_type.model)
-

--- a/startup_scripts/070_rack_roles.py
+++ b/startup_scripts/070_rack_roles.py
@@ -2,7 +2,14 @@ from dcim.models import RackRole
 from ruamel.yaml import YAML
 from utilities.forms import COLOR_CHOICES
 
-with open('/opt/netbox/initializers/rack_roles.yml', 'r') as stream:
+from pathlib import Path
+import sys
+
+file = Path('/opt/netbox/initializers/rack_roles.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml=YAML(typ='safe')
   rack_roles = yaml.load(stream)
 

--- a/startup_scripts/080_racks.py
+++ b/startup_scripts/080_racks.py
@@ -3,8 +3,14 @@ from tenancy.models import Tenant
 from extras.models import CustomField, CustomFieldValue
 from dcim.constants import RACK_TYPE_CHOICES, RACK_WIDTH_CHOICES
 from ruamel.yaml import YAML
+from pathlib import Path
+import sys
 
-with open('/opt/netbox/initializers/racks.yml', 'r') as stream:
+file = Path('/opt/netbox/initializers/racks.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   racks = yaml.load(stream)
 

--- a/startup_scripts/090_device_roles.py
+++ b/startup_scripts/090_device_roles.py
@@ -2,7 +2,14 @@ from dcim.models import DeviceRole
 from ruamel.yaml import YAML
 from utilities.forms import COLOR_CHOICES
 
-with open('/opt/netbox/initializers/device_roles.yml', 'r') as stream:
+from pathlib import Path
+import sys
+
+file = Path('/opt/netbox/initializers/device_roles.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml=YAML(typ='safe')
   device_roles = yaml.load(stream)
 

--- a/startup_scripts/100_platforms.py
+++ b/startup_scripts/100_platforms.py
@@ -1,7 +1,14 @@
 from dcim.models import Manufacturer, Platform
 from ruamel.yaml import YAML
 
-with open('/opt/netbox/initializers/platforms.yml', 'r') as stream:
+from pathlib import Path
+import sys
+
+file = Path('/opt/netbox/initializers/platforms.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   platforms = yaml.load(stream)
 

--- a/startup_scripts/110_devices.py
+++ b/startup_scripts/110_devices.py
@@ -6,7 +6,14 @@ from tenancy.models import Tenant
 from extras.models import CustomField, CustomFieldValue
 from ruamel.yaml import YAML
 
-with open('/opt/netbox/initializers/devices.yml', 'r') as stream:
+from pathlib import Path
+import sys
+
+file = Path('/opt/netbox/initializers/devices.yml')
+if not file.is_file():
+  sys.exit()
+
+with file.open('r') as stream:
   yaml = YAML(typ='safe')
   devices = yaml.load(stream)
 


### PR DESCRIPTION
Previously, the startup_scripts would fail if an initializer file was
not present. Now they just ignore missing files.